### PR TITLE
fixes #41  remove home root_url if none mounted in the routes.rb file

### DIFF
--- a/app/views/rails_db/shared/_footer.html.erb
+++ b/app/views/rails_db/shared/_footer.html.erb
@@ -6,13 +6,15 @@
     </div>
     <div class="large-6 columns">
       <ul class="inline-list right">
+        <% if defined?  main_app.root_url %>
         <li>
-          <%= link_to '/' do %>
+          <%= link_to main_app.root_url do %>
             <%= fa_icon 'home' %>
             Home
           <% end %>
         </li>
         <li>|</li>
+        <% end %>
         <li>
           <%= link_to rails_db.root_path do %>
             <%= fa_icon 'list-ul' %>

--- a/app/views/rails_db/shared/_header.html.erb
+++ b/app/views/rails_db/shared/_header.html.erb
@@ -39,6 +39,7 @@
         <% end %>
       </li>
     </ul>
+    <% if defined?  main_app.root_url %>
     <ul class="inline-list right main_nav">
       <li>
         <%= link_to main_app.root_url do %>
@@ -47,6 +48,7 @@
         <% end %>
       </li>
     </ul>
+    <% end %>
     <div class='clear'></div>
   </div>
 </div>


### PR DESCRIPTION
Not sure if this is how you wanted it fixed for #41 
also changed the footer from using "/" path to using  `main_app.root_url` to make this consistant with the _header template and also if fix if the app is name spaced under a different path