### PR TITLE
fix use paramters to generate url in rails 5

### DIFF
--- a/app/helpers/rails_db/application_helper.rb
+++ b/app/helpers/rails_db/application_helper.rb
@@ -52,5 +52,12 @@ module RailsDb
       result
     end
 
+    def params_to_hash(p)
+      if p.respond_to?(:to_unsafe_h)
+        p.to_unsafe_h
+      else
+        p
+      end
+    end
   end
 end

--- a/app/helpers/rails_db/tables_helper.rb
+++ b/app/helpers/rails_db/tables_helper.rb
@@ -32,7 +32,7 @@ module RailsDb
 
     def table_pagination_path
       params.delete(:pk_id)
-      params.merge({action: :data})
+      params_to_hash params.merge({action: :data})
     end
 
     def column_is_checked?(table_name, column_name)

--- a/app/views/rails_db/tables/data.js.erb
+++ b/app/views/rails_db/tables/data.js.erb
@@ -11,4 +11,4 @@ $(document).foundation('reflow');
 
 $(document).scrollTop(0);
 
-set_browser_url('<%= url_for(params) %>');
+set_browser_url('<%= url_for(params_to_hash(params)) %>');

--- a/app/views/rails_db/tables/show.js.erb
+++ b/app/views/rails_db/tables/show.js.erb
@@ -11,4 +11,4 @@ $(document).foundation('reflow');
 
 $(document).scrollTop(0);
 
-set_browser_url('<%= url_for(params) %>');
+set_browser_url('<%= url_for(params_to_hash(params)) %>');


### PR DESCRIPTION
In rails 5, param can't be used to generate url unless it's permitted.

Simply change it to hash. 

But it still doesn't work in rails 5, because the other gem ransack also used ActionController::Parameters  as variable passed to the url_for method.