### PR TITLE
Use env helper

### DIFF
--- a/lib/generators/templates/rails_db.rb
+++ b/lib/generators/templates/rails_db.rb
@@ -1,7 +1,7 @@
 if Object.const_defined?('RailsDb')
   RailsDb.setup do |config|
     # # enabled or not
-    # config.enabled = Rails.env.to_s == 'development'
+    # config.enabled = Rails.env.development?
 
     # # automatic engine routes mounting
     # config.automatic_routes_mount = true


### PR DESCRIPTION
Using `Rails.env.development?` secures you against typos actually changing the environment.