### PR TITLE
explicitly use https for fontawesome assets

### DIFF
--- a/app/views/layouts/rails_db/application.html.erb
+++ b/app/views/layouts/rails_db/application.html.erb
@@ -2,7 +2,7 @@
 <html>
 <head>
   <title><%= [yield(:title), 'Rails DB'].reject(&:blank?).join(' - ') %></title>
-  <%= stylesheet_link_tag    "//cdnjs.cloudflare.com/ajax/libs/font-awesome/4.5.0/css/font-awesome.min.css" %>
+  <%= stylesheet_link_tag    "https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.5.0/css/font-awesome.min.css" %>
   <%= stylesheet_link_tag    "rails_db/application", media: "all" %>
   <%= javascript_include_tag "rails_db/application" %>
   <%= csrf_meta_tags %>


### PR DESCRIPTION
Hello, this might seem like nitpicking but I think it makes sense to always use `https` for external assets, no matter what. I am actually using CSP and with the current solution I have to whitelist the fontawesome asset twice, the http version for dev and test, plus the https version for production. There is no wildcard for the scheme. Anyway I think it is good practice to force https.