### PR TITLE
Explicitly initialize ActiveRecord

### DIFF
--- a/lib/rails_db.rb
+++ b/lib/rails_db.rb
@@ -3,6 +3,7 @@ require 'codemirror-rails'
 require 'terminal-table'
 require 'csv'
 require 'simple_form'
+require 'active_record'
 require 'ransack'
 require 'kaminari'
 

--- a/lib/rails_db/connection.rb
+++ b/lib/rails_db/connection.rb
@@ -3,6 +3,8 @@ module RailsDb
 
     def connection
       ActiveRecord::Base.connection
+    rescue ActiveRecord::ConnectionNotEstablished
+      ActiveRecord::Base.establish_connection(Rails.application.config.database_configuration[Rails.env]).connection
     end
 
     def columns

--- a/rails_db.gemspec
+++ b/rails_db.gemspec
@@ -21,6 +21,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'codemirror-rails'
   s.add_dependency 'terminal-table'
   s.add_dependency 'simple_form', '>= 4.0.1'
+  s.add_dependency 'activerecord'
   s.add_dependency 'ransack'
   s.add_dependency 'kaminari'
 


### PR DESCRIPTION
I'm developing a Rails application which is using [Sequel ORM](https://github.com/jeremyevans/sequel) and which doesn't use ActiveRecord. `rails_db` depends on ActiveRecord and assumes that ActiveRecord is initialized which is not the case for some RoR applications (like mine).

After these changes `rails_db` worked for me.

I think that `rails_db` should manage its dependency on `activerecord` on its own instead of just assuming that it is already initialized by the host application. While this is true for majority of RoR apps, this is not the case for some of them. Simple inclusion of ActiveRecord as a dependency fixes the issue for the case with no harm for others.