### PR TITLE
Add Role Support

### DIFF
--- a/app/controllers/rails_db/application_controller.rb
+++ b/app/controllers/rails_db/application_controller.rb
@@ -3,6 +3,8 @@ module RailsDb
     helper :all
     helper_method :per_page
 
+    around_action :set_database_role, if: -> { RailsDb.database_role.present? }
+
     before_action :verify_access
 
     if RailsDb.http_basic_authentication_enabled
@@ -11,6 +13,12 @@ module RailsDb
     end
 
     private
+
+    def set_database_role
+      ActiveRecord::Base.connected_to(role: RailsDb.database_role) do
+        yield
+      end
+    end
 
     def verify_access
       result = RailsDb.verify_access_proc.call(self)

--- a/lib/rails_db.rb
+++ b/lib/rails_db.rb
@@ -49,6 +49,9 @@ module RailsDb
   mattr_accessor :verify_access_proc
   @@verify_access_proc = proc { |controller| true }
 
+  mattr_accessor :database_role
+  @@database_role = nil
+
   def self.setup
     yield(self)
   end
@@ -59,6 +62,7 @@ module RailsDb
     self.black_list_tables                  = self.white_list_tables = []
     self.http_basic_authentication_enabled  = false
     self.verify_access_proc                 = proc { |controller| true }
+    self.database_role                      = nil
   end
 
 end

--- a/lib/rails_db/connection.rb
+++ b/lib/rails_db/connection.rb
@@ -2,7 +2,11 @@ module RailsDb
   module Connection
 
     def connection
-      ActiveRecord::Base.connection
+      if RailsDb.database_role.present?
+        ActiveRecord::Base.connection_handler.retrieve_connection(ActiveRecord::Base.name, role: RailsDb.database_role)
+      else
+        ActiveRecord::Base.connection
+      end
     rescue ActiveRecord::ConnectionNotEstablished
       ActiveRecord::Base.establish_connection(Rails.application.config.database_configuration[Rails.env]).connection
     end


### PR DESCRIPTION
This PR allows specifying a Database Role. Primary use case being a read replica for view only.

Rails 6.1 brought in connection handling which makes this super easy.

This was built quickly so if I missed any areas please let me know. Also, this has no test coverage so happy to take feedback on how to improve/perform that.