### PR TITLE
Fix broken link to table helper

### DIFF
--- a/app/views/rails_db/dashboard/data_table.html.erb
+++ b/app/views/rails_db/dashboard/data_table.html.erb
@@ -16,4 +16,4 @@
 
 <br/>
 
-<p><%= link_to 'More Options for Data Tables ==>', 'https://github.com/igorkasyanchuk/rails_db/blob/master/app/helpers/rails_db/rails_db_data_table_helper.rb' %></p>
+<p><%= link_to 'More Options for Data Tables ==>', 'https://github.com/igorkasyanchuk/rails_db/blob/master/app/helpers/rails_db/tables_helper.rb' %></p>


### PR DESCRIPTION
I noticed that the current link on `/rails/db/data-table` page is broken. I'm not sure what the intended link is but I _think_ it was supposed to be to [https://github.com/igorkasyanchuk/rails_db/blob/master/app/helpers/rails_db/tables_helper.rb](https://github.com/igorkasyanchuk/rails_db/blob/master/app/helpers/rails_db/tables_helper.rb).

This PR updates the link.