### PR TITLE
Fix delete issue in base_adapter.rb

### DIFF
--- a/lib/rails_db/adapters/base_adapter.rb
+++ b/lib/rails_db/adapters/base_adapter.rb
@@ -59,7 +59,7 @@ module RailsDb
 
       def self.delete(table_name, pk_name, pk_id)
         case pk_id
-          when Fixnum, Bignum then
+          when Integer then
             execute("DELETE FROM #{table_name} WHERE #{pk_name} = #{pk_id};")
           else
             execute("DELETE FROM #{table_name} WHERE #{pk_name} = '#{pk_id}';")


### PR DESCRIPTION
I encountered this error `NameError - uninitialized constant RailsDb::Adapters::BaseAdapter::Fixnum:`. Seems like since Ruby 2.4, Fixnum and Bignum were unified into Integer.