### PR TITLE
Allow multi-database configuration via AR base model selection

### DIFF
--- a/app/controllers/rails_db/application_controller.rb
+++ b/app/controllers/rails_db/application_controller.rb
@@ -4,6 +4,7 @@ module RailsDb
     helper_method :per_page
 
     before_action :verify_access
+    before_action :set_abstract_model_class
 
     if RailsDb.http_basic_authentication_enabled
       http_basic_authenticate_with name: RailsDb.http_basic_authentication_user_name,
@@ -21,6 +22,13 @@ module RailsDb
       params[:per_page] || session[:per_page]
     end
 
+    def set_abstract_model_class
+      return unless params[:abstract_model_class].present?
+
+      if (found = RailsDb.available_abstract_model_classes.find { |klass| klass.name == params[:abstract_model_class] })
+        RailsDb.abstract_model_class = found
+      end
+    end
   end
 end
 

--- a/app/views/rails_db/shared/_sidebar.html.erb
+++ b/app/views/rails_db/shared/_sidebar.html.erb
@@ -1,3 +1,22 @@
+<% if RailsDb.available_abstract_model_classes.many? %>
+  Do you want to see tables from a specific model base class?
+  <ul>
+    <% RailsDb.available_abstract_model_classes.each do |klass| %>
+      <li>
+        <% if klass == RailsDb.abstract_model_class %>
+          <strong>
+            <%= klass.name %>
+          </strong>
+        <% else %>
+          <%= link_to root_path(abstract_model_class: klass.name) do %>
+            <%= klass.name %>
+          <% end %>
+        <% end %>
+      </li>
+    <% end %>
+  </ul>
+<% end %>
+
 <h3>Tables</h3>
 
 <input id='rails_db_tables_input' placeholder='... quick filter by table name'>

--- a/lib/generators/templates/rails_db.rb
+++ b/lib/generators/templates/rails_db.rb
@@ -26,5 +26,11 @@ if Object.const_defined?('RailsDb')
 
     # # Sandbox mode (only read-only operations)
     # config.sandbox = false
+
+    # # Configure to use something else than ActiveRecord::Base
+    # config.abstract_model_class = ApplicationRecord
+
+    # # Configure for multi-database environments to switch base models in the GUI
+    # config.available_abstract_model_classes = [ApplicationRecord, Tenant1::Base, Tenant2::Base]
   end
 end

--- a/lib/rails_db.rb
+++ b/lib/rails_db.rb
@@ -49,9 +49,13 @@ module RailsDb
   mattr_accessor :verify_access_proc
   @@verify_access_proc = proc { |controller| true }
 
-  ## Configure this in multi-database environments
+  ## Switch out the ActiveRecord::Base class by any abstract descendant
   mattr_accessor :abstract_model_class
   @@abstract_model_class = ActiveRecord::Base
+
+  ## Configure this in multi-database environments
+  mattr_accessor :available_abstract_model_classes
+  @@available_abstract_model_classes = [ActiveRecord::Base]
 
   def self.setup
     yield(self)
@@ -64,6 +68,7 @@ module RailsDb
     self.http_basic_authentication_enabled  = false
     self.verify_access_proc                 = proc { |controller| true }
     self.abstract_model_class               = ActiveRecord::Base
+    self.available_abstract_model_classes   = [ActiveRecord::Base]
   end
 
 end

--- a/lib/rails_db.rb
+++ b/lib/rails_db.rb
@@ -49,6 +49,10 @@ module RailsDb
   mattr_accessor :verify_access_proc
   @@verify_access_proc = proc { |controller| true }
 
+  ## Configure this in multi-database environments
+  mattr_accessor :abstract_model_class
+  @@abstract_model_class = ActiveRecord::Base
+
   def self.setup
     yield(self)
   end
@@ -59,6 +63,7 @@ module RailsDb
     self.black_list_tables                  = self.white_list_tables = []
     self.http_basic_authentication_enabled  = false
     self.verify_access_proc                 = proc { |controller| true }
+    self.abstract_model_class               = ActiveRecord::Base
   end
 
 end

--- a/lib/rails_db/adapters/base_adapter.rb
+++ b/lib/rails_db/adapters/base_adapter.rb
@@ -8,7 +8,7 @@ module RailsDb
 
       def self.execute_with_sandbox_if_needed
         if RailsDb.sandbox
-          ActiveRecord::Base.transaction do
+          RailsDb.abstract_model_class.transaction do
             yield
             raise ActiveRecord::Rollback
           end

--- a/lib/rails_db/connection.rb
+++ b/lib/rails_db/connection.rb
@@ -2,9 +2,9 @@ module RailsDb
   module Connection
 
     def connection
-      ActiveRecord::Base.connection
+      RailsDb.abstract_model_class.connection
     rescue ActiveRecord::ConnectionNotEstablished
-      ActiveRecord::Base.establish_connection(Rails.application.config.database_configuration[Rails.env]).connection
+      RailsDb.abstract_model_class.establish_connection(Rails.application.config.database_configuration[Rails.env]).connection
     end
 
     def columns

--- a/lib/rails_db/table.rb
+++ b/lib/rails_db/table.rb
@@ -48,7 +48,7 @@ module RailsDb
 
     def create_model(table_name, &block)
       begin
-        klass = Class.new(ActiveRecord::Base) do
+        klass = Class.new(RailsDb.abstract_model_class) do
           def self.model_name
             ActiveModel::Name.new(self, nil, table_name)
           end
@@ -57,7 +57,7 @@ module RailsDb
         end
         klass.count # verify that it works, if not load other, hack
       rescue
-        klass = ActiveRecord::Base.descendants.detect { |c| c.table_name == table_name }
+        klass = RailsDb.abstract_model_class.descendants.detect { |c| c.table_name == table_name }
       end
 
       add_ransack_methods(klass) if ransack_version >= Gem::Version.new('4.0.0')


### PR DESCRIPTION
This is a proper follow-up to #129. We add two configuration options:

* `abstract_model_class`
  All explorative calls in this gem will be redirected to this class. Default is `ActiveRecord::Base`.
* `available_abstract_model_classes`
  If there is more than one entry, the GUI will allow you to select `abstract_model_class`. Default is `[ActiveRecord::Base]`

**Remarks:**
I decided against reorganizing `RailsDb::Connection` and `RailsDb::Database` to keep compatibility for older Rails versions. This is also the reason why there must be two config options. The better way forward would probably be to look at the database configuration (`ActiveRecord::DatabaseConfigurations`) instead. So this PR doesn't fix the fallback in `lib/rails_db/connection.rb:7`. It is still broken for Rails >= 6.1.

**Impression:**
<img width="463" alt="CleanShot 2024-01-25 at 12 06 05@2x" src="https://github.com/igorkasyanchuk/rails_db/assets/245443/94d12899-3341-43d7-9656-b7d6d2bc95af">