### PR TITLE
Fix for Rails 7.1 missing callback action

### DIFF
--- a/app/controllers/rails_db/tables_controller.rb
+++ b/app/controllers/rails_db/tables_controller.rb
@@ -1,6 +1,6 @@
 module RailsDb
   class TablesController < RailsDb::ApplicationController
-    LOAD_TABLE_ACTIONS = [:show, :data, :csv, :truncate, :destroy, :edit, :update, :xlsx, :search, :new, :create]
+    LOAD_TABLE_ACTIONS = [:show, :data, :csv, :truncate, :destroy, :edit, :update, :xlsx, :build_search, :new, :create]
 
     before_action :find_table, only: LOAD_TABLE_ACTIONS
 

--- a/app/controllers/rails_db/tables_controller.rb
+++ b/app/controllers/rails_db/tables_controller.rb
@@ -1,6 +1,6 @@
 module RailsDb
   class TablesController < RailsDb::ApplicationController
-    LOAD_TABLE_ACTIONS = [:show, :data, :csv, :truncate, :destroy, :edit, :update, :xlsx, :build_search, :new, :create]
+    LOAD_TABLE_ACTIONS = [:show, :data, :csv, :truncate, :destroy, :edit, :update, :xlsx, :new, :create]
 
     before_action :find_table, only: LOAD_TABLE_ACTIONS
 


### PR DESCRIPTION
Resolves https://github.com/igorkasyanchuk/rails_db/issues/134

## Problem

In Rails 7.1, the new default behavior for missing callbacks is:

```
AbstractController::ActionNotFound - The search action could not be found for the :find_table
callback on RailsDb::TablesController, but it is listed in the controller's
:only option.
Raising for missing callback actions is a new default in Rails 7.1, if you'd
like to turn this off you can delete the option from the environment configurations
or set `config.action_controller.raise_on_missing_callback_actions` to `false`.:
```

## Solution

It turns out that the `:search` method was not defined anywhere, and thus was a missing from the `LOAD_TABLE_ACTIONS` list for the `find_table` callback. Simply removing this fixed the problem.