### PR TITLE
Add csv to .gemspec

### DIFF
--- a/rails_db.gemspec
+++ b/rails_db.gemspec
@@ -24,6 +24,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'ransack', '>= 2.3.2'
   s.add_dependency 'kaminari'
   s.add_dependency 'sprockets-rails'
+  s.add_dependency 'csv'
 
   s.add_development_dependency "launchy"
   s.add_development_dependency "sqlite3", '~> 1.4'


### PR DESCRIPTION
## Problem

In Ruby v3.3 the following warning occurs when launching a `rails console`:

```
/Users/ben/.rbenv/versions/3.3.1/lib/ruby/gems/3.3.0/gems/bootsnap- \
1.18.3/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:30: warning: \
/Users/ben/.rbenv/versions/3.3.1/lib/ruby/3.3.0/csv.rb was loaded from the standard library, \
but will no longer be part of the default gems since Ruby 3.4.0. Add csv to your Gemfile or gemspec.
```

## Solution

Add `csv` gem as a dependency to `rails_db`. Console issues go away with this change.

The fix can be tested by executing `rails new` in a Ruby 3.3.1 environment and than adding the `rails_db` and `bundle`. Start a `rails console` and see the warning. Then update the Gemfile to `gem "rails_db", git: "https://github.com/bpurinton/rails_db.git", branch: "bp-fix-csv-deprecation-warning"` and `gem update rails_db`. Start another console and the errors are gone.