### PR TITLE
Use raw field name in ransack column titles

### DIFF
--- a/app/views/rails_db/tables/_data.html.erb
+++ b/app/views/rails_db/tables/_data.html.erb
@@ -73,7 +73,7 @@
         <% end %>
         <% @model.column_names.each do |column| %>
           <th class="column_<%= column %>" style="<%= display_style_column(@table.name, column)%>">
-            <%= sort_link @q, column, controller: :tables, action: :data %>
+            <%= sort_link @q, column, column, controller: :tables, action: :data %>
           </th>
         <% end %>
       </tr>
@@ -97,7 +97,7 @@
             <th colspan="2">Actions</th>
           <% end %>
           <% @model.column_names.each do |column| %>
-            <th> <%= sort_link @q, column, controller: :tables, action: :data %> </th>
+            <th> <%= sort_link @q, column, column, controller: :tables, action: :data %> </th>
           <% end %>
         </tr>
       </tfoot>

--- a/app/views/rails_db/tables/_search.html.erb
+++ b/app/views/rails_db/tables/_search.html.erb
@@ -55,7 +55,7 @@
           <th colspan="2">Actions</th>
         <% end %>
         <% @model.column_names.each do |column| %>
-          <th> <%= sort_link(@q, column) %> </th>
+          <th> <%= sort_link(@q, column, column) %> </th>
         <% end %>
       </tr>
     </thead>


### PR DESCRIPTION
## Problem

By default, Ransack's [sort_link helper method](https://activerecord-hackery.github.io/ransack/getting-started/simple-mode/#search-link-helper) uses the second argument of the database table's field name and titleizes it, thus modifying things like `director_id` to be `Director`. This is confusing for foreign keys. Furthermore, since this tool is meant to be a view into the database (with minimal alteration to the names of tables and fields), I think it makes sense to avoid altering field names at all, and presenting the true, original table field names in the record viewing table.

## Solution

`sort_link` accepts a third argument, which is a custom label. When this third argument is passed as `column` (the name of the field), instead of manipulating the column name, ransack just uses the value as is.

### View before this change:

![image](https://github.com/user-attachments/assets/a930ecac-21c0-4f6a-9ded-cc7aa1b88c75)

![image](https://github.com/user-attachments/assets/202b6b3e-c674-425b-91cf-797f70b3fb89)

### View after this change:

![image](https://github.com/user-attachments/assets/1433666e-c7d9-4a3c-89cd-660de9ff0d03)

![image](https://github.com/user-attachments/assets/f6f3699d-a838-4906-b5b7-aa7cbeef174e)

### Initializer option?

If this solution is not desired everywhere, then it could be added as a configuration option in the initializer, but I'm not sure that such a minimal cosmetic difference requires the option to turn off / on.