### PR TITLE
Fix column header/value misalignment in table data view

### DIFF
--- a/app/views/rails_db/tables/_data.html.erb
+++ b/app/views/rails_db/tables/_data.html.erb
@@ -71,7 +71,7 @@
         <% if @table.primary_key %>
           <th colspan="2">Actions</th>
         <% end %>
-        <% @model.column_names.each do |column| %>
+        <% @table.column_names.each do |column| %>
           <th class="column_<%= column %>" style="<%= display_style_column(@table.name, column)%>">
             <%= sort_link @q, column, column, controller: :tables, action: :data %>
           </th>
@@ -96,7 +96,7 @@
           <% if @table.primary_key %>
             <th colspan="2">Actions</th>
           <% end %>
-          <% @model.column_names.each do |column| %>
+          <% @table.column_names.each do |column| %>
             <th> <%= sort_link @q, column, column, controller: :tables, action: :data %> </th>
           <% end %>
         </tr>


### PR DESCRIPTION
## Problem

In the table data view (`/rails_db/tables/:id/data`), the column **headers** and the column **values** can end up misaligned, so each header sits above the wrong columns data.

## Root cause

The view builds the two halves of the table from different sources:

- **Headers** (`app/views/rails_db/tables/_data.html.erb`): `@model.column_names`, which comes from the ActiveRecord model and therefore the **schema cache**.
- **Cells** (`app/views/rails_db/tables/_row.html.erb`): `@table.columns`, which comes from `connection.columns(table)`, i.e. **directly from the database**.

These two historically returned columns in the same order, so the inconsistency was latent. **Rails 8.1** changed schema cache dumps to sort columns alphabetically:

```ruby
# activerecord 8.1 .../connection_adapters/schema_cache.rb  (SchemaCache#encode_with)
coder["columns"] = @columns.sort.to_h.transform_values { _1.sort_by(&:name) }
```

So any app that boots from a dumped schema cache (`db:schema:cache:dump`) now gets `@model.column_names` in **alphabetical** order, while `@table.columns` stays in **database/physical** order. Headers and values no longer line up.

It only reproduces when a dumped schema cache is loaded (typical in production/staging). With a live connection both sources agree, which is why it does not show up in development.

## Fix

Build the header row from `@table.column_names`, the same source already used by the cells (`_row.html.erb`) and by the column settings panel (`_data.html.erb`). Headers and values then share one consistent order (the database order), regardless of how the schema cache is serialized.

Two lines changed, both in `_data.html.erb` (thead and tfoot).
